### PR TITLE
Add implicit conversion from Future[Seq[T]] to Buffer[T] and Future[T…

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx/Buffer.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Buffer.scala
@@ -1,6 +1,7 @@
 package pl.metastack.metarx
 
 import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * A buffer is a reactive ordered list of elements
@@ -78,6 +79,12 @@ object Buffer {
     }
 
     result
+  }
+
+  implicit def FutureToReadBuffer[T](future: Future[Seq[T]]) (implicit exec: ExecutionContext): ReadBuffer[T] = {
+    val buf = Buffer[T]()
+    future.foreach(buf.set)
+    buf
   }
 }
 

--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -1,5 +1,7 @@
 package pl.metastack.metarx
 
+import scala.concurrent.{ExecutionContext, Future}
+
 object Channel {
   type Observer[T, U] = T => Result[U]
 
@@ -16,6 +18,12 @@ object Channel {
     val pub = res.publish(write)
     res.subscribe(read, pub)
     res
+  }
+
+  implicit def FutureToReadChannel[T](future: Future[T]) (implicit exec: ExecutionContext): ReadChannel[T] = {
+    val chan = Channel[T]()
+    future.foreach(chan.produce)
+    chan
   }
 }
 


### PR DESCRIPTION
See #1.

I tested it in Skeleton (test code here should probably be added), but it seemed I needed to hint to the compiler:

  val result = headword.filterCycles.filter(_.nonEmpty).flatMap { hw =>
    initial  := false
    headword := ""

    (ServerOps.Dictionary.lookUp(hw).map {
      case Response.Success(r) => r.text
      case _ => ""
    }).asInstanceOf[ReadChannel[String]]
  }

Is it something that could be done to avoid the asInstanceOf or similar?

I think Opt will be supported automatically, but have not tested.