### PR TITLE
Support Opt.fromOption with Future[Option[T]]

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx/Opt.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Opt.scala
@@ -106,6 +106,12 @@ object Opt {
   def apply[T](): Opt[T] = new Opt[T]()
   def apply[T](value: T): Opt[T] = new Opt(Some(value))
 
+  def fromOption[T](future: Future[Option[T]])(implicit exec: ExecutionContext): Opt[T] = {
+    val opt = new Opt[T]()
+    future.foreach(v => opt.produce(v))
+    opt
+  }
+
   def from[T](future: Future[T])(implicit exec: ExecutionContext): Opt[T] = {
     val opt = new Opt[T]()
     future.foreach(v => opt.produce(Some(v)))

--- a/shared/src/test/scala/pl/metastack/metarx/OptTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/OptTest.scala
@@ -138,4 +138,15 @@ object OptTest extends SimpleTestSuite {
       assertEquals(opt.get, Some(42))
     }
   }
+
+  test("Conversion from Future[Option[_]]") {
+    val p = Promise[Option[Int]]()
+    val f = p.future
+    val opt = Opt.fromOption(f)
+    assertEquals(opt.get, None)
+    p.success(Some(42))
+    f.onComplete { v =>
+      assertEquals(opt.get, Some(42))
+    }
+  }
 }


### PR DESCRIPTION
I tried to DRY the code with:

def from[T](future: Future[T])(implicit exec: ExecutionContext): Opt[T] = fromOption(future.map( value => Some(value)))

but the test failed...