### PR TITLE
Add implicit logical operators for ReadChannel[Boolean]

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -14,18 +14,25 @@ package object metarx extends OptImplicits {
   }
 
   implicit class ReadChannelBooleanExtensions(rch: ReadChannel[Boolean]) {
+    def otherWithOperation(other: ReadChannel[Boolean], operator: (Boolean, Boolean) => Boolean) = {
+      rch.flatMap(thisVal => other.map(otherVal => operator(thisVal, otherVal)))
+    }
+    def booleanWithOperation(argument: Boolean, operator: (Boolean, Boolean) => Boolean): ReadChannel[Boolean] = {
+      rch.map(value => operator(value, argument))
+    }
+
     def &&(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
-      rch.flatMap (thisVal => other.map(otherVal => thisVal && otherVal) )
+      otherWithOperation(other, _ && _)
     }
     def &&(argument: Boolean): ReadChannel[Boolean] = {
-      rch.map(value => value && argument)
+      booleanWithOperation(argument, _ && _)
     }
 
     def ||(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
-      rch.flatMap (thisVal => other.map(otherVal => thisVal || otherVal) )
+      otherWithOperation(other, _ || _)
     }
     def ||(argument: Boolean): ReadChannel[Boolean] = {
-      rch.map(value => value || argument)
+      booleanWithOperation(argument, _ || _)
     }
 
     def isFalse: ReadChannel[Boolean] = rch.map(!_)

--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -12,4 +12,31 @@ package object metarx extends OptImplicits {
       opt := Some(t)
     }
   }
+
+  implicit class ReadChannelBooleanExtensions(rch: ReadChannel[Boolean]) {
+    def &&(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
+      rch.flatMap (thisVal => other.map(otherVal => thisVal && otherVal) )
+    }
+    def &&(argument: Boolean): ReadChannel[Boolean] = {
+      rch.map(value => value && argument)
+    }
+
+    def ||(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
+      rch.flatMap (thisVal => other.map(otherVal => thisVal || otherVal) )
+    }
+    def ||(argument: Boolean): ReadChannel[Boolean] = {
+      rch.map(value => value || argument)
+    }
+
+    def isFalse: ReadChannel[Boolean] = rch.map(!_)
+    def unary_! = isFalse
+
+    def onTrue: ReadChannel[Unit] = rch.collect { case true => Unit }
+    def onFalse: ReadChannel[Unit] = rch.collect { case false => Unit }
+  }
+
+  implicit class BooleanExtensions(boolVal: Boolean) {
+    def &&(rch: ReadChannel[Boolean]): ReadChannel[Boolean] = rch && boolVal
+    def ||(rch: ReadChannel[Boolean]): ReadChannel[Boolean] = rch || boolVal
+  }
 }

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -686,4 +686,158 @@ object ChannelTest extends SimpleTestSuite {
       assertEquals(intValues, Seq(42))
     }
   }
+
+  test("Logical tests for ReadChannel[Boolean]") {
+    import pl.metastack.metarx._
+
+    val ch1 = Channel[Boolean]()
+
+    val chRes = Channel[Boolean]()
+    var states = mutable.ArrayBuffer.empty[Boolean]
+    chRes.attach(states += _)
+
+    chRes << !ch1
+
+    ch1 := true
+    ch1 := false
+
+    assertEquals(states, mutable.ArrayBuffer(false, true))
+
+    val trueRes = ch1.onTrue
+    val falseRes = ch1.onFalse
+
+    var numTrues = 0
+    trueRes.attach(_ => numTrues += 1)
+    var numFalses = 0
+    falseRes.attach(_ => numFalses += 1)
+    assertEquals(numTrues, 0)
+    assertEquals(numFalses, 0)
+
+    ch1 := true
+    assertEquals(numTrues, 1)
+    assertEquals(numFalses, 0)
+
+    ch1 := false
+    assertEquals(numTrues, 1)
+    assertEquals(numFalses, 1)
+  }
+
+  test("Logical operators for ReadChannel[Boolean]") {
+    import pl.metastack.metarx._
+
+    val ch1 = Channel[Boolean]()
+    val ch2 = Channel[Boolean]()
+
+    val andRes = Channel[Boolean]()
+    var andStates = mutable.ArrayBuffer.empty[Boolean]
+    andRes.attach(andStates += _)
+
+    val orRes = Channel[Boolean]()
+    var orStates = mutable.ArrayBuffer.empty[Boolean]
+    orRes.attach(orStates += _)
+
+    andRes << (ch1 && ch2)
+    orRes << (ch1 || ch2)
+
+    ch1 := false
+    ch2 := false
+
+    ch1 := true
+    ch2 := false
+
+    ch1 := false
+    ch2 := true
+
+    ch1 := true
+    ch2 := true
+
+    assertEquals(andStates, mutable.ArrayBuffer(false, false, false, true))
+    assertEquals(orStates, mutable.ArrayBuffer(false, true, true, true))
+  }
+
+  test("Logical operators for Var[Boolean]") {
+    import pl.metastack.metarx._
+
+    val ch1 = Var[Boolean](false)
+    val ch2 = Var[Boolean](false)
+
+    val andRes = Channel[Boolean]()
+    var andStates = mutable.ArrayBuffer.empty[Boolean]
+    andRes.attach(andStates += _)
+
+    val orRes = Channel[Boolean]()
+    var orStates = mutable.ArrayBuffer.empty[Boolean]
+    orRes.attach(orStates += _)
+
+    andRes << (ch1 && ch2)
+    orRes << (ch1 || ch2)
+
+    ch1 := true
+    ch2 := true
+
+    ch2 := false
+
+    assertEquals(andStates, mutable.ArrayBuffer(false, false, true, false))
+    assertEquals(orStates, mutable.ArrayBuffer(false, true, true, true))
+  }
+
+  test("Logical operators between Channel[Boolean] and Boolean") {
+    import pl.metastack.metarx._
+
+    val ch = Channel[Boolean]()
+    var inputBoolean = false
+
+    val andRes = Channel[Boolean]()
+    var andStates = mutable.ArrayBuffer.empty[Boolean]
+    andRes.attach(andStates += _)
+
+    val orRes = Channel[Boolean]()
+    var orStates = mutable.ArrayBuffer.empty[Boolean]
+    orRes.attach(orStates += _)
+
+    andRes << (ch && inputBoolean)
+    orRes << (ch || inputBoolean)
+
+    ch := false
+    ch := true
+
+    inputBoolean = true
+    andRes << (ch && inputBoolean)
+    orRes << (ch || inputBoolean)
+    ch := false
+    ch := true
+
+    assertEquals(andStates, mutable.ArrayBuffer(false, false, false, false, false, true))
+    assertEquals(orStates, mutable.ArrayBuffer(false, true, false, true, true, true))
+  }
+
+  test("Logical operators between Boolean and Channel[Boolean]") {
+    import pl.metastack.metarx._
+
+    val ch = Channel[Boolean]()
+    var inputBoolean = false
+
+    val andRes = Channel[Boolean]()
+    var andStates = mutable.ArrayBuffer.empty[Boolean]
+    andRes.attach(andStates += _)
+
+    val orRes = Channel[Boolean]()
+    var orStates = mutable.ArrayBuffer.empty[Boolean]
+    orRes.attach(orStates += _)
+
+    andRes << (inputBoolean && ch)
+    orRes << (inputBoolean || ch)
+
+    ch := false
+    ch := true
+
+    inputBoolean = true
+    andRes << (ch && inputBoolean)
+    orRes << (ch || inputBoolean)
+    ch := false
+    ch := true
+
+    assertEquals(andStates, mutable.ArrayBuffer(false, false, false, false, false, true))
+    assertEquals(orStates, mutable.ArrayBuffer(false, true, false, true, true, true))
+  }
 }


### PR DESCRIPTION
Operators &&, || and !, as well as isTrue() and isFalse() transformations
Closes #9 

The tests could probably be written more DRY, but they works for now.