### PR TITLE
Operator support for some channel parameters

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -1,5 +1,7 @@
 package pl.metastack
 
+import scala.math.{Fractional, Numeric}
+
 package object metarx extends OptImplicits {
   implicit def FunctionToWriteChannel[T](f: T => Unit): WriteChannel[T] = {
     val ch = Channel[T]()
@@ -13,31 +15,35 @@ package object metarx extends OptImplicits {
     }
   }
 
-  implicit class ReadChannelBooleanExtensions(rch: ReadChannel[Boolean]) {
-    def otherWithOperation(other: ReadChannel[Boolean], operator: (Boolean, Boolean) => Boolean) = {
+  abstract class ReadChannelExtensionBase[T](rch: ReadChannel[T]) {
+    def otherWithOperation(other: ReadChannel[T], operator: (T, T) => T) = {
       rch.flatMap(thisVal => other.map(otherVal => operator(thisVal, otherVal)))
     }
-    def booleanWithOperation(argument: Boolean, operator: (Boolean, Boolean) => Boolean): ReadChannel[Boolean] = {
+
+    def TWithOperation(argument: T, operator: (T, T) => T): ReadChannel[T] = {
       rch.map(value => operator(value, argument))
     }
+  }
 
-    def &&(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
+  implicit class ReadChannelBooleanExtensions(rch: ReadChannel[Boolean]) extends ReadChannelExtensionBase(rch) {
+    def &&(other: ReadChannel[Boolean]): ReadChannel[Boolean] = {
       otherWithOperation(other, _ && _)
     }
+
     def &&(argument: Boolean): ReadChannel[Boolean] = {
-      booleanWithOperation(argument, _ && _)
+      TWithOperation(argument, _ && _)
     }
 
-    def ||(other: ReadChannel[Boolean]): ReadChannel[Boolean] =  {
+    def ||(other: ReadChannel[Boolean]): ReadChannel[Boolean] = {
       otherWithOperation(other, _ || _)
     }
+
     def ||(argument: Boolean): ReadChannel[Boolean] = {
-      booleanWithOperation(argument, _ || _)
+      TWithOperation(argument, _ || _)
     }
 
     def isFalse: ReadChannel[Boolean] = rch.map(!_)
     def unary_! = isFalse
-
     def onTrue: ReadChannel[Unit] = rch.collect { case true => Unit }
     def onFalse: ReadChannel[Unit] = rch.collect { case false => Unit }
   }
@@ -45,5 +51,59 @@ package object metarx extends OptImplicits {
   implicit class BooleanExtensions(boolVal: Boolean) {
     def &&(rch: ReadChannel[Boolean]): ReadChannel[Boolean] = rch && boolVal
     def ||(rch: ReadChannel[Boolean]): ReadChannel[Boolean] = rch || boolVal
+  }
+
+  implicit class ReadChannelNumericExtensions[T: Numeric](rch: ReadChannel[T])(implicit num: Numeric[T]) extends ReadChannelExtensionBase(rch) {
+    import num._
+
+    def +(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, plus)
+    def +(argument: T): ReadChannel[T] = TWithOperation(argument, plus)
+    def -(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, minus)
+    def -(argument: T): ReadChannel[T] = TWithOperation(argument, minus)
+    def *(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, times)
+    def *(argument: T): ReadChannel[T] = TWithOperation(argument, times)
+
+    def unary_-(other: ReadChannel[T]): ReadChannel[T] = rch.map(-_)
+
+    def toInt: ReadChannel[Int] = rch.map(_.toInt)
+    def toLong: ReadChannel[Long] = rch.map(_.toLong)
+    def toFloat: ReadChannel[Float] = rch.map(_.toFloat)
+    def toDouble: ReadChannel[Double] = rch.map(_.toDouble)
+  }
+
+  implicit class NumericExtensions[T: Numeric](value: T)(implicit num: Numeric[T]) {
+    import num._
+
+    def +(other: ReadChannel[T]): ReadChannel[T] = other.map(plus(value, _))
+    def -(other: ReadChannel[T]): ReadChannel[T] = other.map(minus(value, _))
+    def *(other: ReadChannel[T]): ReadChannel[T] = other.map(times(value, _))
+  }
+
+  implicit class ReadChannelIntegralExtensions[T: Integral](rch: ReadChannel[T])(implicit num: Integral[T]) extends ReadChannelExtensionBase(rch) {
+    import num._
+
+    def /(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, quot)
+    def /(arg: T): ReadChannel[T] = TWithOperation(arg, quot)
+    def %(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, rem)
+  }
+
+  implicit class IntegralExtensions[T: Integral](value: T)(implicit num: Integral[T]) {
+    import num._
+
+    def /(other: ReadChannel[T]): ReadChannel[T] = other.map(quot(value, _))
+    def %(other: ReadChannel[T]): ReadChannel[T] = other.map(rem(value, _))
+  }
+
+  implicit class ReadChannelFractionalExtensions[T: Fractional](rch: ReadChannel[T])(implicit num: Fractional[T]) extends ReadChannelExtensionBase(rch) {
+    import num._
+
+    def /(other: ReadChannel[T]): ReadChannel[T] = otherWithOperation(other, div)
+    def /(arg: T): ReadChannel[T] = TWithOperation(arg, div)
+  }
+
+  implicit class FractionalExtensions[T: Fractional](value: T)(implicit num: Fractional[T]) {
+    import num._
+
+    def /(other: ReadChannel[T]): ReadChannel[T] = other.map(div(value, _))
   }
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -237,10 +237,16 @@ trait ReadChannel[T]
       Result.Next(t == value)
     }.distinct
 
+  def is(other: ReadChannel[T]): ReadChannel[Boolean] = {
+    zip(other).map { case (a, b) => a == b }
+  }
+
   def isNot(value: T): ReadChannel[Boolean] =
     forkUni { t =>
       Result.Next(t != value)
     }.distinct
+
+  def isNot(other: ReadChannel[T]): ReadChannel[Boolean] = !is(other)
 
   def flatMap[U](f: T => ReadChannel[U]): ReadChannel[U] =
     forkUniFlat(value => Result.Next(f(value)))

--- a/shared/src/main/scala/pl/metastack/metarx/reactive/stream/Is.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/reactive/stream/Is.scala
@@ -9,7 +9,13 @@ import pl.metastack.metarx.ReadChannel
 trait Is[T] {
   /** Current value is equal to `value` */
   def is(value: T): ReadChannel[Boolean]
+  def is(value: ReadChannel[T]): ReadChannel[Boolean]
+  def ===(value: T) = is(value)
+  def ===(value: ReadChannel[T]) = is(value)
 
   /** Current value is not equal to `value` */
   def isNot(value: T): ReadChannel[Boolean]
+  def isNot(value: ReadChannel[T]): ReadChannel[Boolean]
+  def !===(value: T) = isNot(value)
+  def !===(value: ReadChannel[T]) = isNot(value)
 }

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelSpec.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelSpec.scala
@@ -70,6 +70,14 @@ object ChannelSpec extends SimpleTestSuite {
     forallChVal((ch, value) => (ch.is(value), ch.isNot(value).map(!_)))
   }
 
+  test("equal operators") {
+    forallChVal((ch, value) => (ch === value, (ch !=== value) map(!_) ))
+  }
+
+  test("equal operators") {
+    forallCh((ch) => (ch === ch, (ch !=== ch) map(!_) ))
+  }
+
   /* TODO Generalise values */
   test("head") {
     // TODO Use Channel.fromSeq()

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -840,4 +840,72 @@ object ChannelTest extends SimpleTestSuite {
     assertEquals(andStates, mutable.ArrayBuffer(false, false, false, false, false, true))
     assertEquals(orStates, mutable.ArrayBuffer(false, true, false, true, true, true))
   }
+
+  test("Logical operators between Channel[Numeric]") {
+    val ch1 = Channel[Int]()
+    val ch2 = Channel[Int]()
+
+    val plusRes = ch1 + ch2
+    var plusStates = mutable.ArrayBuffer.empty[Int]
+    plusRes.attach(plusStates += _)
+
+    val negRes = ch1 - ch2
+    var negStates = mutable.ArrayBuffer.empty[Int]
+    negRes.attach(negStates += _)
+
+    ch1 := 5
+    ch2 := 4
+
+    assertEquals(plusStates, mutable.ArrayBuffer(9))
+    assertEquals(negStates, mutable.ArrayBuffer(1))
+  }
+
+  test("Logical division between Channel[Integral]") {
+    val ch1 = Channel[Int]()
+    val ch2 = Channel[Int]()
+
+    val divRes = ch1 / ch2
+    var divStates = mutable.ArrayBuffer.empty[Int]
+    divRes.attach(divStates += _)
+
+    val remRes = ch1 % ch2
+    var remStates = mutable.ArrayBuffer.empty[Double]
+    remRes.attach(remStates += _)
+
+    ch1 := 5
+    ch2 := 4
+
+    assertEquals(divStates, mutable.ArrayBuffer(1))
+    assertEquals(remStates, mutable.ArrayBuffer(1))
+  }
+
+  test("Logical division between Integral and Channel[Integral]") {
+    val var1 = Var[Int](5)
+    val res = 10 / var1
+
+    assertEquals(res.cache.get, Some(2))
+  }
+
+
+  test("Logical division between Channel[Fractional]") {
+    val ch1 = Channel[Double]()
+    val ch2 = Channel[Double]()
+
+    val divRes = ch1 / ch2
+    var divStates = mutable.ArrayBuffer.empty[Double]
+    divRes.attach(divStates += _)
+
+    ch1 := 5
+    ch2 := 4
+
+    assertEquals(divStates, mutable.ArrayBuffer(1.25))
+  }
+
+  test("Logical division between Fractional and Channel[Fractional]") {
+    val var1 = Var(5.0)
+    val res = 10.0 / var1
+
+    assertEquals(res.cache.get, Some(2.0))
+  }
+
 }


### PR DESCRIPTION
This allows huge simplifications in cases like this (avoiding map and flatMap or zip):

val progressCompleteness = currentWizardStepNumber.toDouble / numberOfSteps.toDouble
val progressBarContent = span((progressCompleteness * 100).toInt, "%")
...
ProgressBar(progressBarContent).progress(progressCompleteness),