### PR TITLE
Add implicit conversion from WriteChannel to function

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -7,6 +7,11 @@ package object metarx extends OptImplicits {
     ch
   }
 
+  implicit def WriteChannelToFunction[T](f: WriteChannel[T]): T => Unit = {
+    t: T =>
+      f.produce(t)
+  }
+
   implicit class OptExtensions[T](opt: Opt[T]) {
     def :=(t: T) {
       opt := Some(t)

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -840,4 +840,21 @@ object ChannelTest extends SimpleTestSuite {
     assertEquals(andStates, mutable.ArrayBuffer(false, false, false, false, false, true))
     assertEquals(orStates, mutable.ArrayBuffer(false, true, false, true, true, true))
   }
+
+  test("implicit conversion from WriteChannel to function") {
+
+    type IntFunc = Int => Unit
+
+    val receiveChannel = Channel[Int]()
+    var received = mutable.ArrayBuffer.empty[Int]
+    receiveChannel.attach(received += _)
+
+    val writeChannel = receiveChannel.asInstanceOf[WriteChannel[Int]]
+    val func: IntFunc = writeChannel
+
+    func(3)
+    func(9)
+
+    assertEquals(received, mutable.ArrayBuffer(3, 9))
+  }
 }


### PR DESCRIPTION
This will help for APIs requiring callback functions for results/events.