### PR TITLE
Support for Ordering implicit conversion for ReadChannel[Ordering]

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -106,4 +106,27 @@ package object metarx extends OptImplicits {
 
     def /(other: ReadChannel[T]): ReadChannel[T] = other.map(div(value, _))
   }
+
+  implicit class ReadChannelOrderingExtensions[T: Ordering](rch: ReadChannel[T])(implicit ord: Ordering[T]) extends ReadChannelExtensionBase(rch) {
+    import ord._
+
+    def <(other: ReadChannel[T]): ReadChannel[Boolean] = rch.zipWith(other)(_ < _)
+    def <=(other: ReadChannel[T]): ReadChannel[Boolean] = rch.zipWith(other)(_ <= _)
+    def <(arg: T): ReadChannel[Boolean] = rch.map(_ < arg)
+    def <=(arg: T): ReadChannel[Boolean] = rch.map(_ <= arg)
+
+    def >(other: ReadChannel[T]): ReadChannel[Boolean] = rch.zipWith(other)(_ > _)
+    def >=(other: ReadChannel[T]): ReadChannel[Boolean] = rch.zipWith(other)(_ >= _)
+    def >(arg: T): ReadChannel[Boolean] = rch.map(_ > arg)
+    def >=(arg: T): ReadChannel[Boolean] = rch.map(_ >= arg)
+  }
+
+  implicit class OrderingExtensions[T: Ordering](value: T)(implicit ord: Ordering[T]) {
+    import ord._
+
+    def >(other: ReadChannel[T]): ReadChannel[Boolean] = other.map(value > _)
+    def >=(other: ReadChannel[T]): ReadChannel[Boolean] = other.map(value >= _)
+    def <(other: ReadChannel[T]): ReadChannel[Boolean] = other.map(value < _)
+    def <=(other: ReadChannel[T]): ReadChannel[Boolean] = other.map(value <= _)
+  }
 }

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -923,4 +923,38 @@ object ChannelTest extends SimpleTestSuite {
     assertEquals(res.cache.get, Some(2.0))
   }
 
+  test("Logical operators for Var[Ordering]") {
+    import pl.metastack.metarx._
+
+    val ch1 = Var[Int](6)
+    val ch2 = Var[Int](5)
+
+    val ch1Bigger = ch1 > ch2
+    var ch1BiggerStates = mutable.ArrayBuffer.empty[Boolean]
+    ch1Bigger.attach(ch1BiggerStates += _)
+
+    val ch1LessOrEq = ch1 <= ch2
+    var ch1LessOrEqStates = mutable.ArrayBuffer.empty[Boolean]
+    ch1LessOrEq.attach(ch1LessOrEqStates += _)
+
+    ch2 := 6
+    ch2 := 5
+
+    assertEquals(ch1BiggerStates, mutable.ArrayBuffer(true, false, true))
+    assertEquals(ch1LessOrEqStates, mutable.ArrayBuffer(false, true, false))
+  }
+
+  test("Logical operators between Ordering and Channel[Ordering]") {
+    val ch1 = Channel[Int]()
+
+    val ch1Bigger = 5 < ch1
+    var ch1BiggerStates = mutable.ArrayBuffer.empty[Boolean]
+    ch1Bigger.attach(ch1BiggerStates += _)
+
+    ch1 := 5
+    ch1 := 4
+    ch1 := 6
+
+    assertEquals(ch1BiggerStates, mutable.Buffer(false, false, true))
+  }
 }


### PR DESCRIPTION
This add support for operators <, >, <= and >= for supporting types.
Fixes #26.