### PR TITLE
Add utility zip() methods for more than two input channels to avoid n…

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -123,6 +123,18 @@ trait ReadChannel[T]
     res
   }
 
+  // Utility methods for zipping more than two channels, to avoid nested tuples
+  def zip[U, V](other1: ReadChannel[U], other2: ReadChannel[V]): ReadChannel[(T, U, V)] = {
+    zip(other1).zip(other2).map { z => (z._1._1, z._1._2, z._2) }
+  }
+  def zip[U, V, W](other1: ReadChannel[U], other2: ReadChannel[V], other3: ReadChannel[W]): ReadChannel[(T, U, V, W)] = {
+    zip(other1, other2).zip(other3).map { z => (z._1._1, z._1._2, z._1._3, z._2) }
+  }
+  def zip[U, V, W, X](other1: ReadChannel[U], other2: ReadChannel[V], other3: ReadChannel[W],
+                      other4: ReadChannel[X]): ReadChannel[(T, U, V, W, X)] = {
+    zip(other1, other2, other3).zip(other4).map { z => (z._1._1, z._1._2, z._1._3, z._1._4, z._2) }
+  }
+
   def zipWith[U, V](other: ReadChannel[U])(f: (T, U) => V): ReadChannel[V] =
     zip(other).map(f.tupled)
 

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -366,6 +366,24 @@ object ChannelTest extends SimpleTestSuite {
     assertEquals(value, (24, 43))
   }
 
+  test("zip() with multiple inputs") {
+    val ch = Var(0)
+    val ch2 = Var(1)
+    val ch3 = Var("abc")
+    val ch4 = Var(3)
+
+    val zip = ch.zip(ch2, ch3, ch4)
+
+    var values = mutable.ArrayBuffer.empty[(Int, Int, String, Int)]
+    zip.attach(values += _)
+
+    assertEquals(values, Seq((0, 1, "abc", 3)))
+
+    ch4 := 10
+    ch3 := "def"
+    assertEquals(values, Seq((0, 1, "abc", 3), (0, 1, "abc", 10), (0, 1, "def", 10)))
+  }
+
   test("zipWith()") {
     val ch = Var(0)
     val ch2 = Var(1)


### PR DESCRIPTION
…ested tuples.

Fixes #18.

This could easily be extended to more inputs if someone needs more than 5 (!) input channels.