### PR TITLE
Subscriber fixes

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -11,12 +11,6 @@ sealed class Sub[T](init: T) extends Var[T](init) {
     old.foreach(_.dispose())
   }
 
-//  override def produce(value: T): Unit = {
-//    val old = subscription.getAndSet(None)
-//    old.foreach(_.dispose())
-//    super.produce(value)
-//  }
-
   def :=(subscriber: ReadChannel[T]): Unit = produce(subscriber)
 
   override def :=(value: T): Unit = {

--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -11,13 +11,19 @@ sealed class Sub[T](init: T) extends Var[T](init) {
     old.foreach(_.dispose())
   }
 
-  override def produce(value: T): Unit = {
-    val old = subscription.getAndSet(None)
-    old.foreach(_.dispose())
-    super.produce(value)
-  }
+//  override def produce(value: T): Unit = {
+//    val old = subscription.getAndSet(None)
+//    old.foreach(_.dispose())
+//    super.produce(value)
+//  }
 
   def :=(subscriber: ReadChannel[T]): Unit = produce(subscriber)
+
+  override def :=(value: T): Unit = {
+    val old = subscription.getAndSet(None)
+    old.foreach(_.dispose())
+    super.:=(value)
+  }
 
   def detach(): Unit = {
     val old = subscription.getAndSet(None)

--- a/shared/src/test/scala/pl/metastack/metarx/SubTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/SubTest.scala
@@ -33,6 +33,15 @@ object SubTest extends SimpleTestSuite {
 
     subscriber := 200
     assertEquals(values, Seq(0, 23, 42, 404, 200))
+
+    subscriber := x + y
+    assertEquals(values, Seq(0, 23, 42, 404, 200, 42))
+
+    y := 500
+    assertEquals(values, Seq(0, 23, 42, 404, 200, 42, 521))
+
+    x := 100
+    assertEquals(values, Seq(0, 23, 42, 404, 200, 42, 521, 600))
   }
 
   test("get") {


### PR DESCRIPTION
Created a unit test to represent the bug and updated `Sub` to override `:=` instead of `produce`. This may not be a long-term solution, but it's a usable short-term fix.

@tindzk, please take a look and merge it if you agree with the changes or feel free to make changes to better fit intended functionality. BTW, your `SubTest` is a really bad representation of testing specs. :-p