### PR TITLE
Introduce SyncScheduler

### DIFF
--- a/js/src/main/scala/pl/metastack/metarx/AsyncScheduler.scala
+++ b/js/src/main/scala/pl/metastack/metarx/AsyncScheduler.scala
@@ -24,12 +24,19 @@ class AsyncScheduler extends Scheduler {
   def clearInterval(task: Interval): Unit =
     js.Dynamic.global.clearInterval(task)
 
-  def schedule(interval: FiniteDuration, r: Runnable): Cancelable = {
+  override def scheduleOnce(r: Runnable): Cancelable = {
+    r.run()
+    Cancelable()
+  }
+
+  override def schedule(interval: FiniteDuration, r: Runnable): Cancelable = {
     val task = setInterval(interval.toMillis, r)
     Cancelable(clearInterval(task))
   }
 
-  def scheduleOnce(initialDelay: FiniteDuration, r: Runnable): Cancelable = {
+  override def scheduleOnce(initialDelay: FiniteDuration,
+                            r: Runnable
+                           ): Cancelable = {
     val task = setTimeout(initialDelay.toMillis, r)
     Cancelable(clearTimeout(task))
   }

--- a/js/src/main/scala/pl/metastack/metarx/Platform.scala
+++ b/js/src/main/scala/pl/metastack/metarx/Platform.scala
@@ -1,5 +1,5 @@
 package pl.metastack.metarx
 
-object Platform {
+object Platform extends DefaultScheduler {
   implicit lazy val DefaultScheduler: Scheduler = new AsyncScheduler
 }

--- a/jvm/src/main/scala/pl/metastack/metarx/AsyncScheduler.scala
+++ b/jvm/src/main/scala/pl/metastack/metarx/AsyncScheduler.scala
@@ -1,32 +1,42 @@
 package pl.metastack.metarx
 
-import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{FutureTask, ScheduledExecutorService, TimeUnit}
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
-class AsyncScheduler(s: ScheduledExecutorService,
+class AsyncScheduler(s: => ScheduledExecutorService,
                      ec: ExecutionContext) extends Scheduler {
-  def schedule(interval: FiniteDuration, r: Runnable): Cancelable =
-    schedule(interval.length, interval.unit, r)
+  /** Lazy val because not needed for [[scheduleOnce]] without duration */
+  lazy val executorService = s
 
   def schedule(interval: Long, unit: TimeUnit, r: Runnable): Cancelable = {
     require(interval > 0)
     val initialDelay = interval
-    val task = s.scheduleAtFixedRate(r, initialDelay, interval, unit)
+    val task = executorService.scheduleAtFixedRate(r, initialDelay, interval, unit)
     Cancelable(task.cancel(true))
   }
 
-  def scheduleOnce(initialDelay: FiniteDuration, r: Runnable): Cancelable =
-    scheduleOnce(initialDelay.length, initialDelay.unit, r)
-
-  def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-    if (initialDelay <= 0) {
-      ec.execute(r)
-      Cancelable()
-    } else {
-      val task = s.schedule(r, initialDelay, unit)
-      Cancelable(task.cancel(true))
-    }
+  def scheduleOnce(initialDelay: Long,
+                   unit: TimeUnit,
+                   r: Runnable
+                  ): Cancelable = {
+    require(initialDelay > 0)
+    val task = executorService.schedule(r, initialDelay, unit)
+    Cancelable(task.cancel(true))
   }
+
+  override def schedule(interval: FiniteDuration, r: Runnable): Cancelable =
+    schedule(interval.length, interval.unit, r)
+
+  override def scheduleOnce(r: Runnable): Cancelable = {
+    val task = new FutureTask(r, null)
+    ec.execute(task)
+    Cancelable(task.cancel(true))
+  }
+
+  override def scheduleOnce(initialDelay: FiniteDuration,
+                            r: Runnable
+                           ): Cancelable =
+    scheduleOnce(initialDelay.length, initialDelay.unit, r)
 }

--- a/jvm/src/main/scala/pl/metastack/metarx/Platform.scala
+++ b/jvm/src/main/scala/pl/metastack/metarx/Platform.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
 
-object Platform {
+object Platform extends DefaultScheduler {
   implicit lazy val DefaultScheduler: Scheduler = new AsyncScheduler(
     Executors.newSingleThreadScheduledExecutor(),
     ExecutionContext.Implicits.global)

--- a/shared/src/main/scala/pl/metastack/metarx.scala
+++ b/shared/src/main/scala/pl/metastack/metarx.scala
@@ -2,7 +2,12 @@ package pl.metastack
 
 import scala.math.{Fractional, Numeric}
 
-package object metarx extends OptImplicits with BufferImplicits with ChannelImplicits {
+package object metarx
+  extends OptImplicits
+  with BufferImplicits
+  with ChannelImplicits
+  with DefaultScheduler {
+
   implicit def FunctionToWriteChannel[T](f: T => Unit): WriteChannel[T] = {
     val ch = Channel[T]()
     ch.attach(f)

--- a/shared/src/main/scala/pl/metastack/metarx/Scheduler.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Scheduler.scala
@@ -7,10 +7,16 @@ import scala.concurrent.duration._
  */
 trait Scheduler {
   def schedule(interval: FiniteDuration, r: Runnable): Cancelable
+  def scheduleOnce(action: Runnable): Cancelable
   def scheduleOnce(initialDelay: FiniteDuration, action: Runnable): Cancelable
 
   def schedule(interval: FiniteDuration)(action: => Unit): Cancelable =
     schedule(interval, new Runnable {
+      def run(): Unit = action
+    })
+
+  def scheduleOnce(action: => Unit): Cancelable =
+    scheduleOnce(new Runnable {
       def run(): Unit = action
     })
 
@@ -41,4 +47,8 @@ object Cancelable {
           true
         }
     }
+}
+
+trait DefaultScheduler {
+  implicit val scheduler = new SyncScheduler
 }

--- a/shared/src/main/scala/pl/metastack/metarx/SyncScheduler.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/SyncScheduler.scala
@@ -1,0 +1,16 @@
+package pl.metastack.metarx
+
+import scala.concurrent.duration._
+
+class SyncScheduler extends Scheduler {
+  override def schedule(interval: FiniteDuration, r: Runnable): Cancelable = ???
+
+  override def scheduleOnce(r: Runnable): Cancelable = {
+    r.run()
+    Cancelable()
+  }
+
+  override def scheduleOnce(initialDelay: FiniteDuration,
+                            r: Runnable
+                           ): Cancelable = ???
+}


### PR DESCRIPTION
This is a first attempt to fix #44. `SyncScheduler.scheduleOnce` must be overridden for Swing and passed as an implicit to `attach()`:

```scala
import java.awt.EventQueue

class AwtScheduler extends SyncScheduler {
  override def scheduleOnce(r: Runnable): Cancelable = {
    EventQueue.invokeLater(r)
    Cancelable()
  }
}

implicit val awtScheduler = new AwtScheduler
```

The problem with the current design is that some methods cannot be implemented on `SyncScheduler` and `throttle()` will therefore fail by default, unless `AsyncScheduler` gets imported.