### PR TITLE
make ReadStateChannel into a monad

### DIFF
--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -760,7 +760,7 @@ trait ReadStateChannel[T] extends ReadChannel[T] {
   def get: T
 
   def flatMap[U](f: T => ReadStateChannel[U]): ReadStateChannel[U] = {
-    flatMap(f.asInstanceOf[T => ReadChannel[U]]).cache(f(get).get)
+    flatMap(f: T => ReadChannel[U]).cache(f(get).get)
   }
 
   override def map[U](f: T => U): ReadStateChannel[U] = {

--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -758,6 +758,14 @@ trait ChannelDefaultDispose[T] {
 
 trait ReadStateChannel[T] extends ReadChannel[T] {
   def get: T
+
+  def flatMap[U](f: T => ReadStateChannel[U]): ReadStateChannel[U] = {
+    flatMap(f.asInstanceOf[T => ReadChannel[U]]).cache(f(get).get)
+  }
+
+  override def map[U](f: T => U): ReadStateChannel[U] = {
+    flatMap { x => Var(f(x)) }
+  }
 }
 
 /** In Rx terms, a [[StateChannel]] can be considered a cold observable. */

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -479,10 +479,21 @@ class ChannelTest extends CompatTest {
   test("flatMap() (3)") {
     var value = ""
     Var(42)
-      .flatMap(x => Var(x.toString))
+      .flatMap((x: Int) => Var(x.toString))
       .filter(_ => true)
       .attach(value = _)
     assertEquals(value, "42")
+  }
+
+  test("flatMap() (4)") {
+    val v1 = Var(42)
+    val v2 = v1.map((x: Int) => x + 1)
+    var resultList: List[Int] = List.empty
+    v2.attach{ x => resultList = resultList ++ List(x) }
+    assertEquals (v2.get, 43)
+    v1.update(_ => 43)
+    assertEquals(v2.get, 44)
+    assertEquals(resultList, List(43, 44))
   }
 
   test("flatMapCh()") {


### PR DESCRIPTION
I. e. add a flatMap/map to ReadStateChannel that also return a ReadStateChannel instead of just a ReadChannel.

I'm not sure if this is the right solution performance-wise because currently `cache` is used (so get is called each time we use this flatMap when my understanding is right). This can probably be done better with a more "lazy" approach.

Also, because of this overloading, flatMap(x => code) doesn't work anymore because scala is not able to recognize the type of x (because there are two flatMap's), you can see the necessary change in the diff.

I'd be happy to get feedback of the general idea/specific implementation.