### PR TITLE
Change propagation operator

### DIFF
--- a/jvm/src/test/scala/pl.metastack.metarx/MultithreadingSpec.scala
+++ b/jvm/src/test/scala/pl.metastack.metarx/MultithreadingSpec.scala
@@ -13,7 +13,7 @@ class MultithreadingSpec extends FunSuite {
     val collected = ArrayBuffer.empty[Int]
     ch.attach(collected += _)
 
-    val tasks = (0 until 100).map(i => Future(ch := i))
+    val tasks = (0 until 100).map(i => Future(ch ! i))
     val aggregated = Future.sequence(tasks)
     Await.result(aggregated, 15.seconds)
 

--- a/manual/src/main/scala/pl/metastack/metarx/manual/Examples.scala
+++ b/manual/src/main/scala/pl/metastack/metarx/manual/Examples.scala
@@ -14,7 +14,7 @@ object Examples extends SectionSupport {
 
     isOne.attach(println)
 
-    ch := 1
+    ch ! 1
   }
 
   import pl.metastack.metarx._
@@ -37,13 +37,13 @@ object Examples extends SectionSupport {
     values.attach(println)
 
     // Simulate change of `m` in UI
-    m := 10
+    m ! 10
   }
 
   section("produce") {
     val ch = Channel[Int]() // initialise
     ch.attach(println)      // attach observer
-    ch := 42                // produce value
+    ch ! 42                // produce value
   }
 
   section("chaining") {
@@ -51,8 +51,8 @@ object Examples extends SectionSupport {
     ch.filter(_ > 3)
       .map(_ + 1)
       .attach(println)
-    ch := 42
-    ch := 1
+    ch ! 42
+    ch ! 1
   }
 
   section("merging") {
@@ -63,7 +63,7 @@ object Examples extends SectionSupport {
     val merged: ReadChannel[String] = a.merge(b).merge(c)
     merged.attach(println)
 
-    c := "test"
+    c ! "test"
   }
 
   section("or") {
@@ -74,7 +74,7 @@ object Examples extends SectionSupport {
     val or: ReadChannel[Unit] = a | b | c
     or.attach(println)
 
-    b := "test"
+    b ! "test"
   }
 
   section("logical-operators") {
@@ -104,7 +104,7 @@ object Examples extends SectionSupport {
     ch.attach(println)
 
     val ch2 = Channel[Int]()
-    ch2 := 42  // Value is lost as ch2 does not have any observers
+    ch2 ! 42  // Value is lost as ch2 does not have any observers
     ch2.attach(println)
   }
 
@@ -143,7 +143,7 @@ object Examples extends SectionSupport {
       (str: String) => map.find(_._2 == str).get._1)
     id   .attach(x => println("id   : " + x))
     idMap.attach(x => println("idMap: " + x))
-    idMap := "three"
+    idMap ! "three"
   }
 
   section("bimap-lens") {
@@ -151,7 +151,7 @@ object Examples extends SectionSupport {
     val test = Var(Test(1, 2))
     val lens = test.biMap(_.b, (x: Int) => test.get.copy(b = x))
     test.attach(println)
-    lens := 42
+    lens ! 42
   }
 
   section("lazyvar") {
@@ -172,16 +172,16 @@ object Examples extends SectionSupport {
     val dch = ch.drop(1)
     dch.attach(println)
     dch.attach(println)
-    ch := 23
+    ch ! 23
   }
 
   sectionNoExec("cycle") {
     val todo = Channel[String]()
     todo.attach { t =>
       println(t)
-      todo := ""
+      todo ! ""
     }
-    todo := "42"
+    todo ! "42"
   }
 
   section("buffer") {
@@ -223,12 +223,12 @@ object Examples extends SectionSupport {
     def componentA(): Unit =
       bin.left.attach { x =>
         println(s"Component A received: $x")
-        if (x == 3) bin.right := 42
+        if (x == 3) bin.right ! 42
       }
 
     def componentB(): Unit = {
       bin.right.attach(x => println(s"Component B received: $x"))
-      (1 to 3).foreach(bin.left := _)
+      (1 to 3).foreach(bin.left ! _)
     }
 
     componentA()  // Sends 42 to component B if current value is 3
@@ -237,7 +237,7 @@ object Examples extends SectionSupport {
     // `bin` is a state channel and stores the current value
     println(s"Current value: ${bin.get}")
 
-    bin := 23  // Broadcast to both components
+    bin ! 23  // Broadcast to both components
   }
 
   section("pickling") {
@@ -260,10 +260,10 @@ object Examples extends SectionSupport {
     sub.attach(println)
 
     sub := x  // `sub` will subscribe all values produced on `x`
-    x := 200  // Gets propagated to `sub`
+    x ! 200  // Gets propagated to `sub`
 
-    sub := 10 // Cancel subscription and set value to 10
-    x := 404  // Doesn't get propagated to `sub`
+    sub ! 10 // Cancel subscription and set value to 10
+    x ! 404  // Doesn't get propagated to `sub`
   }
 
   section("mapTo") {

--- a/shared/src/main/scala/pl/metastack/metarx/Bin.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Bin.scala
@@ -18,12 +18,17 @@ class Bin[T](value: T)
   val left  = LazyVar[T](v.get)
   val right = LazyVar[T](v.get)
 
-  left.attach(v.set)
-  right.attach(v.set)
+  private val l = left.attach(v.set)
+  private val r = right.attach(v.set)
 
   attach { value =>
-    left := value
-    right := value
+    left.produce(value, l)
+    right.produce(value, r)
+  }
+
+  def set(value: T): Unit = {
+    v.set(value)
+    produce(value)
   }
 
   def flush(f: T => Unit): Unit = f(v.get)

--- a/shared/src/main/scala/pl/metastack/metarx/Bin.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Bin.scala
@@ -21,14 +21,12 @@ class Bin[T](value: T)
   private val l = left.attach(v.set)
   private val r = right.attach(v.set)
 
-  attach { value =>
+  override def produce(value: T): Unit = {
+    v.set(value)
     left.produce(value, l)
     right.produce(value, r)
-  }
 
-  def set(value: T): Unit = {
-    v.set(value)
-    produce(value)
+    super.produce(value)
   }
 
   def flush(f: T => Unit): Unit = f(v.get)

--- a/shared/src/main/scala/pl/metastack/metarx/Bin.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Bin.scala
@@ -29,6 +29,12 @@ class Bin[T](value: T)
     super.produce(value)
   }
 
+  override def dispose(): Unit = {
+    l.dispose()
+    r.dispose()
+    super.dispose()
+  }
+
   def flush(f: T => Unit): Unit = f(v.get)
 
   def get: T = v.get

--- a/shared/src/main/scala/pl/metastack/metarx/BufSet.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/BufSet.scala
@@ -106,7 +106,7 @@ trait WriteBufSet[T]
   val changes: Channel[Delta[T]]
 
   def insert(value: T) {
-    changes := Delta.Insert(value)
+    changes ! Delta.Insert(value)
   }
 
   def insertAll(values: Set[T]) {
@@ -114,7 +114,7 @@ trait WriteBufSet[T]
   }
 
   def remove(value: T) {
-    changes := Delta.Remove(value)
+    changes ! Delta.Remove(value)
   }
 
   def removeAll(values: Set[T]) {
@@ -137,7 +137,7 @@ trait WriteBufSet[T]
   }
 
   def clear() {
-    changes := Delta.Clear()
+    changes ! Delta.Clear()
   }
 }
 

--- a/shared/src/main/scala/pl/metastack/metarx/Buffer.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Buffer.scala
@@ -623,27 +623,27 @@ trait WriteBuffer[T]
   val changes: WriteChannel[Delta[T]]
 
   def prepend(element: T) {
-    changes := Delta.Insert(Position.Head(), element)
+    changes ! Delta.Insert(Position.Head(), element)
   }
 
   def append(element: T) {
-    changes := Delta.Insert(Position.Last(), element)
+    changes ! Delta.Insert(Position.Last(), element)
   }
 
   def insertBefore(reference: T, element: T) {
-    changes := Delta.Insert(Position.Before(reference), element)
+    changes ! Delta.Insert(Position.Before(reference), element)
   }
 
   def insertAfter(reference: T, element: T) {
-    changes := Delta.Insert(Position.After(reference), element)
+    changes ! Delta.Insert(Position.After(reference), element)
   }
 
   def replace(reference: T, element: T) {
-    changes := Delta.Replace(reference, element)
+    changes ! Delta.Replace(reference, element)
   }
 
   def remove(element: T) {
-    changes := Delta.Remove(element)
+    changes ! Delta.Remove(element)
   }
 
   def appendAll(buf: Seq[T]) {

--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -767,7 +767,7 @@ trait StateChannel[T]
   with ChannelDefaultDispose[T] {
 
   /** Sets and propagates value to children */
-  def set(value: T): Unit
+  def set(value: T): Unit = produce(value)
 
   /** @see [[set]] */
   def :=(value: T): Unit = set(value)

--- a/shared/src/main/scala/pl/metastack/metarx/Channel.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Channel.scala
@@ -68,13 +68,13 @@ trait ReadChannel[T]
 
   def cache: ReadPartialChannel[T] = {
     val res = Opt[T]()
-    res << map(Some(_))
+    attach(res := _)
     res
   }
 
   def cache(default: T): ReadStateChannel[T] = {
     val res = Var[T](default)
-    res << this
+    attach(res := _)
     res
   }
 
@@ -93,8 +93,8 @@ trait ReadChannel[T]
       }
     }
 
-    attach(_ => res := (()))
-    ch.attach(_ => res := (()))
+    attach(_ => res ! (()))
+    ch.attach(_ => res ! (()))
 
     res
   }
@@ -562,7 +562,7 @@ case class FlatChildChannel[T, U](parent: ReadChannel[T],
   def onChannel(ch: ReadChannel[U]) {
     if (subscr != null) subscr.dispose()
     bound = ch
-    subscr = bound.attach(this := _)
+    subscr = bound.attach(this ! _)
   }
 
   def process(value: T) {
@@ -763,9 +763,13 @@ trait ReadStateChannel[T] extends ReadChannel[T] {
 
 /** In Rx terms, a [[StateChannel]] can be considered a cold observable. */
 trait StateChannel[T] extends Channel[T] with ReadStateChannel[T] {
-  def update(f: T => T) {
-    flush(t => produce(f(t)))
-  }
+  /** Sets and propagates value to children */
+  def set(value: T): Unit
+
+  /** @see [[set]] */
+  def :=(value: T) = set(value)
+
+  def update(f: T => T): Unit = set(f(get))
 
   // Shapeless has not been built yet for Scala.js 0.6.0
   /*def value[U](f: shapeless.Lens[T, T] => shapeless.Lens[T, U]) =

--- a/shared/src/main/scala/pl/metastack/metarx/Dep.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Dep.scala
@@ -6,14 +6,14 @@ class Dep[T, U] private[metarx](sub: Sub[T],
                                 bwd: ReadChannel[U] => ReadChannel[T])
   extends Sub[U](null.asInstanceOf[U]) {
   sub.attach { s =>
-    super.produce(fwd(Var(s)))
+    super.set(fwd(Var(s)))
   }
 
-  override def produce(value: ReadChannel[U]): Unit = {
+  override def set(value: ReadChannel[U]): Unit = {
     sub := bwd(value)
-    super.produce(value)
+    super.set(value)
   }
 
-  override def produce(value: U): Unit =
+  override def set(value: U): Unit =
     sub := bwd(Var(value))
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Dep.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Dep.scala
@@ -6,14 +6,14 @@ class Dep[T, U] private[metarx](sub: Sub[T],
                                 bwd: ReadChannel[U] => ReadChannel[T])
   extends Sub[U](null.asInstanceOf[U]) {
   sub.attach { s =>
-    super.set(fwd(Var(s)))
+    super.produce(fwd(Var(s)))
   }
 
-  override def set(value: ReadChannel[U]): Unit = {
+  override def produce(value: ReadChannel[U]): Unit = {
     sub := bwd(value)
-    super.set(value)
+    super.produce(value)
   }
 
-  override def set(value: U): Unit =
+  override def produce(value: U): Unit =
     sub := bwd(Var(value))
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Dep.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Dep.scala
@@ -5,7 +5,8 @@ class Dep[T, U] private[metarx](sub: Sub[T],
                                 fwd: ReadChannel[T] => ReadChannel[U],
                                 bwd: ReadChannel[U] => ReadChannel[T])
   extends Sub[U](null.asInstanceOf[U]) {
-  sub.attach { s =>
+
+  private val attached = sub.attach { s =>
     super.produce(fwd(Var(s)))
   }
 
@@ -16,4 +17,9 @@ class Dep[T, U] private[metarx](sub: Sub[T],
 
   override def produce(value: U): Unit =
     sub := bwd(Var(value))
+
+  override def dispose(): Unit = {
+    attached.dispose()
+    super.dispose()
+  }
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Dict.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Dict.scala
@@ -157,11 +157,11 @@ trait WriteDict[A, B]
   val changes: WriteChannel[Delta[A, B]]
 
   def insert(key: A, value: B) {
-    changes := Delta.Insert(key, value)
+    changes ! Delta.Insert(key, value)
   }
 
   def update(key: A, value: B) {
-    changes := Delta.Update(key, value)
+    changes ! Delta.Update(key, value)
   }
 
   def insertAll(map: Map[A, B]) {
@@ -169,7 +169,7 @@ trait WriteDict[A, B]
   }
 
   def remove(key: A) {
-    changes := Delta.Remove(key)
+    changes ! Delta.Remove(key)
   }
 
   def removeAll(keys: Seq[A]) {
@@ -177,7 +177,7 @@ trait WriteDict[A, B]
   }
 
   def clear() {
-    changes := Delta.Clear()
+    changes ! Delta.Clear()
   }
 
   def set(map: Map[A, B]) {

--- a/shared/src/main/scala/pl/metastack/metarx/Operators.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Operators.scala
@@ -49,15 +49,6 @@ object Operators {
     def ||(argument: => Boolean): ReadChannel[Out] = map(_ || argument)
 
     def unary_! = map(!_)
-
-    @deprecated("Use `!ch` instead", "v0.1.5")
-    def isFalse: ReadChannel[Out] = unary_!
-
-    @deprecated("Use `collect { case true => () }` instead", "v0.1.5")
-    def onTrue: ReadChannel[Unit] = collect { case true => () }
-
-    @deprecated("Use `collect { case false => () }` instead", "v0.1.5")
-    def onFalse: ReadChannel[Unit] = collect { case false => () }
   }
 
   trait NumericOps[T, Out, ZipOut] extends Base[T, Out, T, ZipOut] {

--- a/shared/src/main/scala/pl/metastack/metarx/Opt.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Opt.scala
@@ -8,14 +8,14 @@ object Opt {
 
   def from[T](future: Future[T])(implicit exec: ExecutionContext): Opt[T] = {
     val opt = Opt[T]()
-    future.foreach(v => opt.produce(Some(v)))
+    future.foreach(v => opt.set(Some(v)))
     opt
   }
 
   def fromOption[T](future: Future[Option[T]])
                    (implicit exec: ExecutionContext): Opt[T] = {
     val opt = Opt[T]()
-    future.foreach(opt.produce)
+    future.foreach(opt.set)
     opt
   }
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -29,7 +29,12 @@ class Sub[T](init: T) extends Var[T](init) {
     new Dep(this, fwd, bwd)
 
   override def toString = s"Sub()"
-  override def dispose(): Unit = detach()
+
+  override def dispose(): Unit = {
+    detach()
+    children.foreach(_.dispose())
+    children.clear()
+  }
 }
 
 object Sub {

--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -6,17 +6,17 @@ class Sub[T](init: T) extends Var[T](init) {
   private val subscription =
     new AtomicReference(Option.empty[ReadChannel[Unit]])
 
-  def produce(subscriber: ReadChannel[T]): Unit = {
-    val old = subscription.getAndSet(Some(subscriber.attach(super.produce)))
+  def set(subscriber: ReadChannel[T]): Unit = {
+    val old = subscription.getAndSet(Some(subscriber.attach(super.set)))
     old.foreach(_.dispose())
   }
 
-  def :=(subscriber: ReadChannel[T]): Unit = produce(subscriber)
+  def :=(subscriber: ReadChannel[T]): Unit = set(subscriber)
 
-  override def produce(value: T): Unit = {
+  override def set(value: T): Unit = {
     val old = subscription.getAndSet(None)
     old.foreach(_.dispose())
-    super.produce(value)
+    super.set(value)
   }
 
   def detach(): Unit = {

--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -35,8 +35,7 @@ class Sub[T](init: T) extends Var[T](init) {
 
   override def dispose(): Unit = {
     detach()
-    children.foreach(_.dispose())
-    children.clear()
+    super.dispose()
   }
 }
 

--- a/shared/src/main/scala/pl/metastack/metarx/Sub.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Sub.scala
@@ -6,17 +6,20 @@ class Sub[T](init: T) extends Var[T](init) {
   private val subscription =
     new AtomicReference(Option.empty[ReadChannel[Unit]])
 
-  def set(subscriber: ReadChannel[T]): Unit = {
-    val old = subscription.getAndSet(Some(subscriber.attach(super.set)))
+  def produce(subscriber: ReadChannel[T]): Unit = {
+    val old = subscription.getAndSet(Some(subscriber.attach(super.produce)))
     old.foreach(_.dispose())
   }
 
+  def !(subscriber: ReadChannel[T]): Unit = produce(subscriber)
+
+  def set(subscriber: ReadChannel[T]): Unit = produce(subscriber)
   def :=(subscriber: ReadChannel[T]): Unit = set(subscriber)
 
-  override def set(value: T): Unit = {
+  override def produce(value: T): Unit = {
     val old = subscription.getAndSet(None)
     old.foreach(_.dispose())
-    super.set(value)
+    super.produce(value)
   }
 
   def detach(): Unit = {

--- a/shared/src/main/scala/pl/metastack/metarx/Var.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Var.scala
@@ -37,8 +37,11 @@ object Var {
 }
 
 /** Upon each subscription, emits `value`, which is evaluated lazily. */
-class LazyVar[T](value: => T) extends StateChannel[T] with ChannelDefaultSize[T] {
-  override def set(value: T): Unit = {}  // TODO Should not be declared
+class LazyVar[T](value: => T)
+  extends Channel[T]
+  with ReadStateChannel[T]
+  with ChannelDefaultSize[T]
+  with ChannelDefaultDispose[T] {
   override def get: T = value
   override def flush(f: T => Unit): Unit = f(value)
 
@@ -48,7 +51,7 @@ class LazyVar[T](value: => T) extends StateChannel[T] with ChannelDefaultSize[T]
 }
 
 object LazyVar {
-  def apply[T](value: => T) = new LazyVar(value)
+  def apply[T](value: => T): LazyVar[T] = new LazyVar(value)
 }
 
 /**
@@ -74,6 +77,6 @@ class PtrVar[T](change: ReadChannel[_], _get: => T, _set: T => Unit)
 }
 
 object PtrVar {
-  def apply[T](change: ReadChannel[_], get: => T, set: T => Unit) =
+  def apply[T](change: ReadChannel[_], get: => T, set: T => Unit): PtrVar[T] =
     new PtrVar[T](change, get, set)
 }

--- a/shared/src/main/scala/pl/metastack/metarx/Var.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/Var.scala
@@ -63,7 +63,7 @@ object LazyVar {
 class PtrVar[T](change: ReadChannel[_], _get: => T, _set: T => Unit)
   extends StateChannel[T] with ChannelDefaultSize[T]
 {
-  change.attach(_ => produce())
+  private val attached = change.attach(_ => produce())
 
   override def get: T = _get
   override def set(value: T): Unit = _set(value)
@@ -76,6 +76,11 @@ class PtrVar[T](change: ReadChannel[_], _get: => T, _set: T => Unit)
   def produce(): Unit = super.produce(get)
 
   override def flush(f: T => Unit): Unit = f(get)
+
+  override def dispose(): Unit = {
+    attached.dispose()
+    super.dispose()
+  }
 
   override def toString = s"PtrVar($get)"
 }

--- a/shared/src/main/scala/pl/metastack/metarx/reactive/propagate/Produce.scala
+++ b/shared/src/main/scala/pl/metastack/metarx/reactive/propagate/Produce.scala
@@ -1,6 +1,9 @@
 package pl.metastack.metarx.reactive.propagate
 
 trait Produce[T] {
+  /** Propagates value to children */
   def produce(value: T)
-  def :=(value: T) = produce(value)
+
+  /** @see [[produce]] */
+  def !(value: T) = produce(value)
 }

--- a/shared/src/test/scala/pl/metastack/metarx/BinSpec.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/BinSpec.scala
@@ -19,7 +19,7 @@ class BinSpec extends WordSpec with Matchers {
     }
 
     "creating binary channels" should {
-      "be initialized to zero" in {
+      "be initialised to zero" in {
         bin.get should be(0)
       }
       "subscribe to updates from main channel" in {
@@ -39,7 +39,7 @@ class BinSpec extends WordSpec with Matchers {
       }
       "update `left`" in {
         reset()
-        bin.left := 42
+        bin.left ! 42
         values should be(empty)
         leftValues should be(Seq(42))
         rightValues should be(empty)
@@ -47,7 +47,7 @@ class BinSpec extends WordSpec with Matchers {
       }
       "update `right`" in {
         reset()
-        bin.right := 23
+        bin.right ! 23
         values should be(empty)
         leftValues should be(empty)
         rightValues should be(Seq(23))

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelSpec.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelSpec.scala
@@ -33,7 +33,7 @@ class ChannelSpec extends CompatTest {
       elems.foreach { value =>
         val (lch, rch) = f(ch, value)
         val cmp = ChannelCompare(lch, rch)
-        ch := value
+        ch ! value
         cmp.tick()
       }
 
@@ -44,7 +44,7 @@ class ChannelSpec extends CompatTest {
       elems.foreach { value =>
         val (lch, rch) = f(ch2, value * 2)
         val cmp = ChannelCompare(lch, rch)
-        ch2 := value
+        ch2 ! value
         cmp.tick()
       }
     }
@@ -68,11 +68,11 @@ class ChannelSpec extends CompatTest {
   }
 
   test("equal operators") {
-    forallChVal((ch, value) => (ch === value, (ch !== value) map(!_) ))
+    forallChVal((ch, value) => (ch === value, (ch !== value).map(!_) ))
   }
 
   test("equal operators (2)") {
-    forallCh((ch) => (ch === ch, (ch !== ch) map(!_) ))
+    forallCh(ch => (ch === ch, (ch !== ch).map(!_) ))
   }
 
   /* TODO Generalise values */

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -29,7 +29,7 @@ class ChannelTest extends CompatTest {
     assertEquals(map(a), 1)
     assertEquals(map(b), 2)
 
-    a := 1
+    a ! 1
 
     assertEquals(map(a), 1)
     assertEquals(map(b), 2)
@@ -49,7 +49,7 @@ class ChannelTest extends CompatTest {
   test("distinct()") {
     val ch = Var(1)
     val dis = ch.distinct
-    ch := 1
+    ch ! 1
     var sum = 0
     dis.attach(sum += _)
     assertEquals(sum, 1)
@@ -106,14 +106,14 @@ class ChannelTest extends CompatTest {
     ch.take(2).attach(items += _)
     assertEquals(ch.children.size, 1)
 
-    ch := 1
-    ch := 2
+    ch ! 1
+    ch ! 2
 
     assertEquals(items, Seq(1, 2))
     assertEquals(ch.children.size, 0)
 
-    ch := 3
-    ch := 4
+    ch ! 3
+    ch ! 4
 
     assertEquals(items, Seq(1, 2))
   }
@@ -124,9 +124,9 @@ class ChannelTest extends CompatTest {
     var items = mutable.ArrayBuffer.empty[Int]
     ch.take(2).attach(items += _)
 
-    ch := 1
-    ch := 2
-    ch := 3
+    ch ! 1
+    ch ! 2
+    ch ! 3
 
     assertEquals(items, Seq(0, 1))
   }
@@ -162,8 +162,8 @@ class ChannelTest extends CompatTest {
     dch.attach(arr  += _)
     dch.attach(arr2 += _)
 
-    ch := 23
-    ch := 3
+    ch ! 23
+    ch ! 3
 
     assertEquals(arr,  mutable.ArrayBuffer(42, 23))
     assertEquals(arr2, mutable.ArrayBuffer(42, 23))
@@ -176,9 +176,9 @@ class ChannelTest extends CompatTest {
     val arr = mutable.ArrayBuffer.empty[Int]
     dch.attach(arr += _)
 
-    ch := 50
-    ch := 10
-    ch := 60
+    ch ! 50
+    ch ! 10
+    ch ! 60
 
     assertEquals(arr, mutable.ArrayBuffer(42, 50))
   }
@@ -189,10 +189,10 @@ class ChannelTest extends CompatTest {
     var sum = 0
     ch.drop(2).attach(sum += _)
 
-    ch := 1
-    ch := 2
-    ch := 3
-    ch := 4
+    ch ! 1
+    ch ! 2
+    ch ! 3
+    ch ! 4
 
     assertEquals(sum, 3 + 4)
   }
@@ -205,7 +205,7 @@ class ChannelTest extends CompatTest {
     dch.attach(arr += _)
     dch.attach(arr += _)
 
-    ch := 5
+    ch ! 5
 
     assertEquals(arr, mutable.ArrayBuffer(5, 5))
   }
@@ -333,11 +333,11 @@ class ChannelTest extends CompatTest {
 
     var sum = 0
     map.attach(value => sum += value)
-    ch := 42
+    ch ! 42
     assertEquals(sum, 43)
 
     map.attach(value => sum += value + 1)
-    ch := 43
+    ch ! 43
     assertEquals(sum, 43 + 44 + 45)
   }
 
@@ -352,7 +352,7 @@ class ChannelTest extends CompatTest {
 
     assertEquals(values, Seq((0, 1)))
 
-    ch := 2
+    ch ! 2
     assertEquals(values, Seq((0, 1), (2, 1)))
   }
 
@@ -365,17 +365,17 @@ class ChannelTest extends CompatTest {
     var value = (-1, -1)
     zip.attach(value = _)
 
-    ch2 := 42
+    ch2 ! 42
     assertEquals(value, (0, 42))
 
     ch := 23
-    ch2 := 42
+    ch2 ! 42
     assertEquals(value, (23, 42))
 
     ch := 24
     assertEquals(value, (23, 42))
 
-    ch2 := 43
+    ch2 ! 43
     assertEquals(value, (24, 43))
   }
 
@@ -394,7 +394,6 @@ class ChannelTest extends CompatTest {
     var2 := 4
     assertEquals(values, Seq((1, 2), (3, 2), (3, 4)))
   }
-
 
   test("zip() with multiple inputs") {
     val ch = Var(0)
@@ -425,7 +424,7 @@ class ChannelTest extends CompatTest {
 
     assertEquals(values, Seq(1))
 
-    ch := 2
+    ch ! 2
     assertEquals(values, Seq(1, 3))
   }
 
@@ -441,12 +440,12 @@ class ChannelTest extends CompatTest {
     var cur = -1
     fmap.attach(cur = _)
 
-    ch := 1
+    ch ! 1
     assertEquals(cur, 0)
     assertEquals(values, mutable.ArrayBuffer(0))
 
-    ch := 2
-    ch2 := 2 /* Previous handlers attached to ch2 must be still valid. */
+    ch ! 2
+    ch2 ! 2 /* Previous handlers attached to ch2 must be still valid. */
     assertEquals(cur, 2)
     assertEquals(values, mutable.ArrayBuffer(0, 2))
   }
@@ -465,15 +464,15 @@ class ChannelTest extends CompatTest {
     var cur = -1
     fmap.attach(cur = _)
 
-    ch := 0
+    ch ! 0
     assertEquals(cur, 2)
-    ch2 := 42
+    ch2 ! 42
     assertEquals(cur, 42)
 
-    ch := 1
+    ch ! 1
     assertEquals(cur, 3)
-    ch3 := 42
-    ch2 := 50 /* ch2 should not be attached anymore to flatMap(). */
+    ch3 ! 42
+    ch2 ! 50 /* ch2 should not be attached anymore to flatMap(). */
     assertEquals(cur, 42)
   }
 
@@ -491,7 +490,7 @@ class ChannelTest extends CompatTest {
     val a = ch.flatMapCh(cur => cur)
     val b = ch.flatMapCh(cur => cur)
 
-    ch := Var(42)
+    ch ! Var(42)
   }
 
   /* test("flatMapCh()") {
@@ -523,10 +522,10 @@ class ChannelTest extends CompatTest {
     var sum = 0
     ch2.attach(sum += _)
 
-    map := 1
+    map ! 1
     ch := 0
 
-    map := 5
+    map ! 5
     assertEquals(sum, 5)
   }
 
@@ -554,10 +553,10 @@ class ChannelTest extends CompatTest {
 
     val ch = chIn.writeTo(chOut)
 
-    chIn := 1
+    chIn ! 1
     assertEquals(out, -1)
 
-    ch := 1
+    ch ! 1
     assertEquals(out, 1)
   }
 
@@ -570,10 +569,10 @@ class ChannelTest extends CompatTest {
 
     assertEquals(out, 5)
 
-    ch := 1
+    ch ! 1
     assertEquals(out, 1)
 
-    ch2 := 2
+    ch2 ! 2
     assertEquals(out, 2)
   }
 
@@ -585,7 +584,7 @@ class ChannelTest extends CompatTest {
 
     assertEquals(out, -1)
 
-    ch := 43
+    ch ! 43
     assertEquals(out, 43)
   }
 
@@ -595,8 +594,8 @@ class ChannelTest extends CompatTest {
     var states = mutable.ArrayBuffer.empty[Boolean]
     ch.isEmpty.attach(states += _)
 
-    ch := 1
-    ch := 2
+    ch ! 1
+    ch ! 2
 
     assertEquals(states, mutable.ArrayBuffer(true, false))
   }
@@ -607,7 +606,7 @@ class ChannelTest extends CompatTest {
     var states = mutable.ArrayBuffer.empty[Boolean]
     ch.isEmpty.attach(states += _)
 
-    ch := 1
+    ch ! 1
 
     assertEquals(states, mutable.ArrayBuffer(false))
   }
@@ -618,8 +617,8 @@ class ChannelTest extends CompatTest {
     var states = mutable.ArrayBuffer.empty[Boolean]
     ch.nonEmpty.attach(states += _)
 
-    ch := 1
-    ch := 2
+    ch ! 1
+    ch ! 2
 
     assertEquals(states, mutable.ArrayBuffer(false, true))
   }
@@ -630,7 +629,7 @@ class ChannelTest extends CompatTest {
     var states = mutable.ArrayBuffer.empty[Boolean]
     ch.nonEmpty.attach(states += _)
 
-    ch := 1
+    ch ! 1
 
     assertEquals(states, mutable.ArrayBuffer(true))
   }
@@ -642,10 +641,10 @@ class ChannelTest extends CompatTest {
     var states = mutable.ArrayBuffer.empty[Int]
     map.attach(states += _)
 
-    ch := 2
-    ch := 3
-    ch := 1
-    ch := 4
+    ch ! 2
+    ch ! 3
+    ch ! 1
+    ch ! 4
 
     assertEquals(states, mutable.ArrayBuffer(42))
   }
@@ -672,11 +671,11 @@ class ChannelTest extends CompatTest {
     var wrStates = mutable.ArrayBuffer.empty[Int]
     wr.attach(wrStates += _)
 
-    rd := 1
+    rd ! 1
     assertEquals(states, mutable.ArrayBuffer(1))
     assertEquals(wrStates, mutable.ArrayBuffer())
 
-    ch := 2
+    ch ! 2
     assertEquals(states, mutable.ArrayBuffer(1, 2))
     assertEquals(wrStates, mutable.ArrayBuffer(2))
   }
@@ -707,7 +706,7 @@ class ChannelTest extends CompatTest {
 
     assertEquals(varInt.get, 1)
 
-    varInt := 2
+    varInt ! 2
     assertEquals(strValues, Seq("1", "2"))
   }
 
@@ -718,7 +717,7 @@ class ChannelTest extends CompatTest {
     ch.values.attach(intValues += _)
     assertEquals(intValues, Seq.empty)
 
-    ch := Some(42)
+    ch ! Some(42)
     assertEquals(intValues, Seq(42))
   }
 
@@ -759,11 +758,11 @@ class ChannelTest extends CompatTest {
     assertEquals(numTrues, 0)
     assertEquals(numFalses, 1)
 
-    ch1 := true
+    ch1 ! true
     assertEquals(numTrues, 1)
     assertEquals(numFalses, 1)
 
-    ch1 := false
+    ch1 ! false
     assertEquals(numTrues, 1)
     assertEquals(numFalses, 2)
   }
@@ -886,7 +885,7 @@ class ChannelTest extends CompatTest {
     var orStates = mutable.ArrayBuffer.empty[Boolean]
     orRes.attach(orStates += _)
 
-    ch := true
+    ch ! true
 
     orRes.dispose()
     inputBoolean = true
@@ -894,7 +893,7 @@ class ChannelTest extends CompatTest {
     var orStates2 = mutable.ArrayBuffer.empty[Boolean]
     orRes2.attach(orStates2 += _)
 
-    ch := false
+    ch ! false
 
     assertEquals(orStates, mutable.ArrayBuffer(false, true))
     assertEquals(orStates2, mutable.ArrayBuffer(true, true))
@@ -917,14 +916,14 @@ class ChannelTest extends CompatTest {
     andRes << (inputBoolean && ch)
     orRes << (inputBoolean || ch)
 
-    ch := false
-    ch := true
+    ch ! false
+    ch ! true
 
     inputBoolean = true
     andRes << (ch && inputBoolean)
     orRes << (ch || inputBoolean)
-    ch := false
-    ch := true
+    ch ! false
+    ch ! true
 
     assertEquals(andStates, mutable.ArrayBuffer(false, false, false, false, false, true))
     assertEquals(orStates, mutable.ArrayBuffer(false, true, false, true, true, true))
@@ -1007,8 +1006,8 @@ class ChannelTest extends CompatTest {
     var ch1LessOrEqStates = mutable.ArrayBuffer.empty[Boolean]
     ch1LessOrEq.attach(ch1LessOrEqStates += _)
 
-    ch2 := 6
-    ch2 := 5
+    ch2 ! 6
+    ch2 ! 5
 
     assertEquals(ch1BiggerStates, mutable.ArrayBuffer(true, false, true))
     assertEquals(ch1LessOrEqStates, mutable.ArrayBuffer(false, true, false))
@@ -1021,9 +1020,9 @@ class ChannelTest extends CompatTest {
     var ch1BiggerStates = mutable.ArrayBuffer.empty[Boolean]
     ch1Bigger.attach(ch1BiggerStates += _)
 
-    ch1 := 5
-    ch1 := 4
-    ch1 := 6
+    ch1 ! 5
+    ch1 ! 4
+    ch1 ! 6
 
     assertEquals(ch1BiggerStates, mutable.Buffer(false, false, true))
   }
@@ -1053,7 +1052,7 @@ class ChannelTest extends CompatTest {
 
     var i = 0
     val task = scheduler.schedule(500.millis) {
-      ch := i
+      ch ! i
       i += 1
     }
 

--- a/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/ChannelTest.scala
@@ -748,8 +748,8 @@ class ChannelTest extends CompatTest {
     ch1 := false
     assertEquals(states, mutable.ArrayBuffer(false, true))
 
-    val trueRes = ch1.onTrue
-    val falseRes = ch1.onFalse
+    val trueRes = ch1.collect { case true => () }
+    val falseRes = ch1.collect { case false => () }
 
     var numTrues = 0
     trueRes.attach(_ => numTrues += 1)
@@ -773,7 +773,7 @@ class ChannelTest extends CompatTest {
     val opt = Opt[Boolean]()
     var count = 0
 
-    val trueCh = opt.onTrue
+    val trueCh = opt.collect { case Some(true) => () }
     trueCh.attach(_ => count += 1)
 
     opt := false

--- a/shared/src/test/scala/pl/metastack/metarx/LazyVarTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/LazyVarTest.scala
@@ -45,10 +45,10 @@ class LazyVarTest extends FunSuite {
     filter.map(_ * 2).attach(value => values += value)
     assert(values == Seq(84))
 
-    ch := 1
+    ch ! 1
     assert(values == Seq(84))
 
-    ch := 2
+    ch ! 2
     assert(values == Seq(84, 4))
   }
 
@@ -60,10 +60,10 @@ class LazyVarTest extends FunSuite {
     take.map(_ + 1).attach(values += _)
     assert(values == Seq(43))
 
-    ch := 1
+    ch ! 1
     assert(values == Seq(43, 2))
 
-    ch := 1
+    ch ! 1
     assert(values == Seq(43, 2))
   }
 

--- a/shared/src/test/scala/pl/metastack/metarx/OptTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/OptTest.scala
@@ -27,13 +27,13 @@ class OptTest extends CompatTest {
 
     y.attach(elems += _)
 
-    x := "a"
+    x ! "a"
 
     ch := 1
-    x := "b"
+    x ! "b"
 
     ch := 2
-    x := "c"
+    x ! "c"
 
     assertEquals(elems, mutable.ArrayBuffer("a0", "b1", "c2"))
 
@@ -41,7 +41,7 @@ class OptTest extends CompatTest {
     val elems2 = mutable.ArrayBuffer.empty[String]
     y.attach(elems2 += _)
     assertEquals(elems, mutable.ArrayBuffer("a0", "b1", "c2"))
-    x := "c"
+    x ! "c"
     assertEquals(elems, mutable.ArrayBuffer("a0", "b1", "c2", "c2"))
     assertEquals(elems2, mutable.ArrayBuffer("c2"))
   }
@@ -79,8 +79,8 @@ class OptTest extends CompatTest {
 
     val x = Opt[Int]()
     x.map(_.isDefined).attach(elements += _)
-    x := Some(42)
-    x := None
+    x ! Some(42)
+    x ! None
 
     assertEquals(elements, mutable.ArrayBuffer(false, true, false))
   }
@@ -93,8 +93,8 @@ class OptTest extends CompatTest {
      .mapValues[Int, Int](_ * 2)
      .orElse(Var(-1))
      .attach(elements += _)
-    x := Some("42")
-    x := None
+    x ! Some("42")
+    x ! None
 
     assertEquals(elements, mutable.ArrayBuffer(-1, 84, -1))
   }
@@ -104,8 +104,8 @@ class OptTest extends CompatTest {
 
     val x = Opt[Int]()
     x.mapOrElse[Int, Int](_ + 1, 42).attach(elements += _)
-    x := Some(23)
-    x := None
+    x ! Some(23)
+    x ! None
 
     assertEquals(elements, mutable.ArrayBuffer(42, 24, 42))
   }
@@ -122,8 +122,8 @@ class OptTest extends CompatTest {
     map.attach(elements += _)
     assertEquals(i, 42)
 
-    x := Some(23)
-    x := None
+    x ! Some(23)
+    x ! None
 
     assertEquals(elements, mutable.ArrayBuffer(42, 24, 42))
   }
@@ -133,9 +133,9 @@ class OptTest extends CompatTest {
 
     val x = Opt[Int]()
     x.contains(5).attach(elements += _)
-    x := Some(23)
-    x := Some(5)
-    x := None
+    x ! Some(23)
+    x ! Some(5)
+    x ! None
 
     assertEquals(elements, mutable.ArrayBuffer(false, false, true, false))
   }

--- a/shared/src/test/scala/pl/metastack/metarx/SchedulerTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/SchedulerTest.scala
@@ -10,7 +10,7 @@ class SchedulerTest extends CompatTest {
     val scheduler: Scheduler = Platform.DefaultScheduler
     var i = 0
     val task = scheduler.schedule(500.millis) {
-      ch := i
+      ch ! i
       i += 1
     }
 

--- a/shared/src/test/scala/pl/metastack/metarx/SubTest.scala
+++ b/shared/src/test/scala/pl/metastack/metarx/SubTest.scala
@@ -29,7 +29,7 @@ class SubTest extends CompatTest {
     y := 21
     assertEquals(values, Seq(0, 23, 42, 404))
 
-    subscriber := 200
+    subscriber ! 200
     assertEquals(values, Seq(0, 23, 42, 404, 200))
 
     subscriber := x + y

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.8-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This pull request changes the propagation operator (currently `:=`).

`:=` gives the false impression that a `Channel` has a state that may be modified, while in fact it only supports value propagation. Therefore, this pull request changes it to `!` which is a common operator in other reactive libraries.

`:=` continues to be available, but only on state channels. It keeps its current semantics (i.e. change the value as well as propagate it to subscribers). Additionally, `!` is now also available on state channels, but unlike `:=` it does not modify the state.